### PR TITLE
Add endpoint to provide application version

### DIFF
--- a/src/main/java/io/github/jhipster/registry/web/rest/AppInfoResource.java
+++ b/src/main/java/io/github/jhipster/registry/web/rest/AppInfoResource.java
@@ -1,0 +1,20 @@
+package io.github.jhipster.registry.web.rest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Created by diego on 22/06/17.
+ */
+public class AppInfoResource {
+
+    @Value("${eureka.instance.metadata-map.version}")
+    private String appVersion;
+
+
+    @GetMapping("/info/version")
+    public String getVersion() {
+        return appVersion;
+    }
+
+}


### PR DESCRIPTION
There is a lack of a simple way to access the current version of Jhipster Registry. It would be useful in the case of checking automatically the current version to ensure that the running version is the desired one (e.g. the one configured in a puppet server). I'm suggesting the endpoint api/info/version that provides a simple text/plain containing the running application version.